### PR TITLE
Fix cli opts for level/part

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,7 @@ int main(int argc, char **argv)
 			{"year", required_argument, NULL, 'y'},
 			{"day", required_argument, NULL, 'd'},
 			{"part", required_argument, NULL, 'l'},
+			{"level", required_argument, NULL, 'l'},
 			{"submit", optional_argument, NULL, 's'},
 			{"input", no_argument, NULL, 'i'},
 			{"directions", no_argument, NULL, 'p'},


### PR DESCRIPTION
The readme and `nog -h` mention `--level` to specify the part to submit but it doesn't work. So, I added `--level=<>` as a cli opt to adhere to readme. Kept `--part=<>` for backwards compatibility.