### PR TITLE
Fix typo in installation instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install curl
 **Linux**  
 ```
 sudo apt update
-sudo apt-get install liburl4-gnutls-dev
+sudo apt-get install libcurl4-gnutls-dev
 # or whatever packager you use
 ```
 #


### PR DESCRIPTION
liburl4-gnutls-dev -> libcurl4-gnutls-dev